### PR TITLE
기본 BasePackage를 설정하는 정책 추가

### DIFF
--- a/spring-trace-core/src/main/java/spring/trace/configuration/EnableTrace.java
+++ b/spring-trace-core/src/main/java/spring/trace/configuration/EnableTrace.java
@@ -15,9 +15,18 @@ import java.lang.annotation.*;
 @Import(TraceRegistrar.class)
 public @interface EnableTrace {
 
+	/**
+	 * basePackages alias
+	 * @return
+	 */
+	String[] value() default {};
+
+	String[] basePackages() default {};
+
+	Class<?>[] basePackageClasses() default {};
+
 	boolean proxyTargetClass() default false;
 
 	AdviceMode mode() default AdviceMode.PROXY;
 
-    String[] basePackages();
 }


### PR DESCRIPTION
기존 @EnableTrace 속성의 basePackages에만 넣던 형태에서

value 속성, basePackages 속성 basePackageClasses 속성의 형태로 넣을 수 있도록 수정 

만약 속성 모두에 패키지 정보가 존재시에는 설정된 모든 패키지 정보를 취합한다. 

그리고 패키지 정보가 없을시에는 @EnableTrace가 설정된 config 클래스의 패키지가 디폴트로 설정 된다.

@ComponetScan 어노테이션 정책과 동일하게 설정
